### PR TITLE
feat: add action shortcuts

### DIFF
--- a/app/components/DrawPad.vue
+++ b/app/components/DrawPad.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useMagicKeys } from '@vueuse/core'
 import SignaturePad from 'signature_pad'
 
 const props = defineProps({
@@ -21,6 +20,12 @@ const emit = defineEmits(['save'])
 const canPost = ref(false)
 const canvas = ref()
 const signaturePad = ref()
+const { metaSymbol } = useShortcuts()
+
+defineShortcuts({
+  meta_z: undo,
+  meta_k: clear,
+})
 
 onMounted(() => {
   signaturePad.value = new SignaturePad(canvas.value, {
@@ -37,14 +42,7 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   window.removeEventListener('resize', resizeCanvas)
-})
-
-const { metaSymbol } = useShortcuts()
-const { meta, z, k } = useMagicKeys()
-
-watchEffect(() => {
-  if (meta.value && z.value) undo()
-  if (meta.value && k.value) clear()
+  signaturePad.value?.off()
 })
 
 function resizeCanvas() {

--- a/app/components/DrawPad.vue
+++ b/app/components/DrawPad.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useMagicKeys } from '@vueuse/core'
 import SignaturePad from 'signature_pad'
 
 const props = defineProps({
@@ -36,6 +37,14 @@ onMounted(() => {
 })
 onBeforeUnmount(() => {
   window.removeEventListener('resize', resizeCanvas)
+})
+
+const { metaSymbol } = useShortcuts()
+const { meta, z, k } = useMagicKeys()
+
+watchEffect(() => {
+  if (meta.value && z.value) undo()
+  if (meta.value && k.value) clear()
 })
 
 function resizeCanvas() {
@@ -106,20 +115,30 @@ async function save() {
         />
       </div>
       <div class="flex items-center">
-        <UButton
-          variant="ghost"
-          color="gray"
-          label="Undo"
-          icon="i-ph-arrow-arc-left"
-          @click="undo"
-        />
-        <UButton
-          variant="ghost"
-          color="gray"
-          icon="i-ph-x"
-          label="Clear"
-          @click="clear"
-        />
+        <UTooltip
+          text="Undo"
+          :shortcuts="[metaSymbol, 'z']"
+        >
+          <UButton
+            variant="ghost"
+            color="gray"
+            label="Undo"
+            icon="i-ph-arrow-arc-left"
+            @click="undo"
+          />
+        </UTooltip>
+        <UTooltip
+          text="Clear"
+          :shortcuts="[metaSymbol, 'k']"
+        >
+          <UButton
+            variant="ghost"
+            color="gray"
+            icon="i-ph-x"
+            label="Clear"
+            @click="clear"
+          />
+        </UTooltip>
       </div>
     </div>
     <UButton


### PR DESCRIPTION
this PR adds `metaKey` + `z` shortcut for `undo` and `metaKey` + `K` for `clear`