### PR TITLE
fix: remove layout shift on images with slower networks

### DIFF
--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -15,7 +15,7 @@ const { data: drawings } = await useFetch('/api/drawings')
         <img
           :src="`/drawings/${drawing.pathname}`"
           :alt="drawing.pathname"
-          class="max-w-[400px] max-h-[400px] w-full h-full rounded"
+          class="max-w-[400px] w-full rounded aspect-1"
           loading="lazy"
         >
         <div class="flex items-center justify-between max-w-[400px]">


### PR DESCRIPTION
## Issue

On slower networks with a fresh browser cache, the images cause janky layout shift :)

<img width="817" alt="Screenshot 2024-06-13 at 10 03 55" src="https://github.com/Atinux/instadraw/assets/37825447/8d0922b6-e7ab-4cfd-a9b9-b74c0885aeb7">

## Solution

Aspect Ratio for the win, image loads into its designated space. content doesn't shift.

## Reproduction

Chrome devtools slow 3g + disable cache